### PR TITLE
Patch-failed-runsheet-generation

### DIFF
--- a/dp_tools/config/bulkRNASeq_vLatest.yaml
+++ b/dp_tools/config/bulkRNASeq_vLatest.yaml
@@ -100,6 +100,7 @@ Staging:
         # an exception will be raised if one and only one url is not mapped to each filename
         - ISA Field Name: 
             - Parameter Value[Merged Sequence Data File]
+            - Characteristics[Merged Sequence Data File]
             - Raw Data File
           ISA Table Source: Assay
           Multiple Values Per Entry: true

--- a/dp_tools/config/bulkRNASeq_vLatest.yaml
+++ b/dp_tools/config/bulkRNASeq_vLatest.yaml
@@ -56,6 +56,7 @@ Staging:
             - spike-in quality control role
             - spike-in protocol
             - spike-in control
+            - spike-in control protocol
           Runsheet Column Name: has_ERCC
           Processing Usage: >-
             Indicates is ERCC spike-in has been added. This can be automatically

--- a/dp_tools/scripts/convert.py
+++ b/dp_tools/scripts/convert.py
@@ -251,8 +251,12 @@ def isa_to_runsheet(accession: str, isaArchive: Path, config: tuple[str, str]):
     for entry in investigation_source_entries:
         # handle special cases
         if entry.get("True If Includes At Least One"):
+            # Addressing non-uniformity in ISA field naming
+            # - remove whitespace before comparing
+            # - convert to all lower case as well
+            isa_entries = {item.strip().lower() for item in i_tables[entry["Investigation Subtable"]][entry["ISA Field Name"]]}
             overlap = set(entry["True If Includes At Least One"]).intersection(
-                set(i_tables[entry["Investigation Subtable"]][entry["ISA Field Name"]])
+                isa_entries
             )
             df_final[entry["Runsheet Column Name"]] = bool(overlap)
             continue


### PR DESCRIPTION
arguably this should be normalized on the ISA metadata side

however this is not a true issue in the Metadata so dp_tools will be flexible with the non-normalize nature