### PR TITLE
fix: add "micro sign" unicode character to whitelist

### DIFF
--- a/dp_tools/bulkRNASeq/checks.py
+++ b/dp_tools/bulkRNASeq/checks.py
@@ -32,7 +32,7 @@ def r_style_make_names(s: str) -> str:
     Returns:
         str: A string converted in the same way as R's make.names function
     """
-    EXTRA_WHITELIST_CHARACTERS = "_ΩπϴλθijkuΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩαβγδεζηθικλμνξοπρστυφχψω"
+    EXTRA_WHITELIST_CHARACTERS = "_ΩπϴλθijkuΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩαβγδεζηθικλμνξοπρστυφχψω_µ" # Note: there are two "μμ" like characters one is greek letter mu, the other is the micro sign
     VALID_CHARACTERS = string.ascii_letters + string.digits + "." + EXTRA_WHITELIST_CHARACTERS
     REPLACEMENT_CHAR = "."
     new_string_chars = list()


### PR DESCRIPTION
this is a sign first observed as a false positive when V&Ving GLDS-346

make.names in R considers this a valid character. This fix syncs with that behaviour