### PR TITLE
fix: remove extra space

### DIFF
--- a/dp_tools/scripts/convert.py
+++ b/dp_tools/scripts/convert.py
@@ -343,7 +343,7 @@ def isa_to_runsheet(accession: str, isaArchive: Path, config: tuple[str, str]):
                                 [
                                     scan_col.startswith("Parameter Value["),
                                     scan_col.startswith("Factor Value["),
-                                    scan_col.startswith("Characteristics ["),
+                                    scan_col.startswith("Characteristics["),
                                 ]
                             ):
                                 break


### PR DESCRIPTION
this had caused Characteristics columns to not trigger the 'another owner' guard